### PR TITLE
updated to latest plyr 2.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-plyr",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A simple, accessible HTML5 media player React Component",
   "main": "lib/index.js",
   "author": "Jose Miguel Bejarano",
@@ -46,7 +46,7 @@
     "rimraf": "^2.6.1"
   },
   "dependencies": {
-    "plyr": "^2.0.12"
+    "plyr": "^2.0.18"
   },
   "peerDependencies": {
     "react": "15.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4598,9 +4598,9 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
-plyr@^2.0.12:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/plyr/-/plyr-2.0.12.tgz#e999d07a0e9e5f3747b00637e46c051675a36d0d"
+plyr@^2.0.18:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/plyr/-/plyr-2.0.18.tgz#91ebb7ffe6a61f4517a8c88ed04036fe95101f4f"
 
 podda@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
There was recently an issue brought up in the Plyr github regarding `getVideoData`. Seems to break the youtube player. This PR just updates the Plyr which includes the fix for this.

```
data.message:"Uncaught TypeError: n.getVideoData is not a function" data.lineNumber:2 data.columnNumber:809 data.errorMessage:"n.getVideoData is not a function" data.stack:"TypeError: n.getVideoData is not a function
    at onReady ()
    at K.f.I (https://s.ytimg.com/yts/jsbin/www-widgetapi-vflnzpyZ4/www-widgetapi.js:66:267)
    at W.f.l (https://s.ytimg.com/yts/jsbin/www-widgetapi-vflnzpyZ4/www-widgetapi.js:114:67)
    at W.f.J (https://s.ytimg.com/yts/jsbin/www-widgetapi-vflnzpyZ4/www-widgetapi.js:127:281)
    at S.g (https://s.ytimg.com/yts/jsbin/www-widgetapi-vflnzpyZ4/www-widgetapi.js:143:270)
    at g (https://s.ytimg.com/yts/jsbin/www-widgetapi-vflnzpyZ4/www-widgetapi.js:95:28)" data.userAgent:"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36" data.browser:"Chrome 61.0.3163 / Mac OS X 10.9.5" 
```


https://github.com/sampotts/plyr/issues/709