### PR TITLE
SSR fix for referenced navigator object in defaultProps.js

### DIFF
--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -109,7 +109,7 @@ const defaultProps = {
   // Captions settings
   captions: {
     active: false,
-    language: (navigator.language || navigator.userLanguage).split('-')[0],
+    language: (typeof navigator !== 'undefined') ? (navigator.language || navigator.userLanguage).split('-')[0] : 'en',
   },
 
   // Fullscreen settings


### PR DESCRIPTION
Unfortunately there was 1 line in defaultProps.js which was causing react-plyr to break our universal react app. I figured it would be safe to simply default to the captions language to `en` if it's ever ran server side.