### PR TITLE
Allows html options.controls as string to replace controls

### DIFF
--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -5,8 +5,6 @@ const defaultProps = {
   // Custom media title
   title: '',
 
-  html: null,
-
   // Logging to console
   debug: false,
 

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,6 @@ class Plyr extends Component {
     onCaptionsDisabled: PropTypes.func,
 
     // plyr props
-    html : PropTypes.string,
     enabled: PropTypes.bool,
     title: PropTypes.string,
     debug: PropTypes.bool,
@@ -107,7 +106,10 @@ class Plyr extends Component {
       enabled: PropTypes.bool,
       key: PropTypes.string
     }),
-    controls: PropTypes.arrayOf(PropTypes.string),
+    controls: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.string
+    ]),
     settings: PropTypes.arrayOf(PropTypes.string),
 
     poster: PropTypes.string,


### PR DESCRIPTION
As per the HTML options in:
https://github.com/sampotts/plyr/blob/master/controls.md