### PR TITLE
Allow captions to be added to videos

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -23,3 +23,28 @@ it('renders a simple Vimeo Video', () => {
   );
   expect(toJson(wrapper)).toMatchSnapshot();
 });
+
+it('renders a simple HTML5 Video with Captions', ()=>{
+  const wrapper = shallow(
+    <Plyr
+    type="video"
+    poster="/path/to/poster.jpg"
+    url="mymovie.mp4"
+    captions={[
+      {
+        kind: 'captions',
+        label: 'English captions',
+        src: '/path/to/english-captions.vtt',
+        srclang: 'en',
+        default: true
+      },
+      {
+        label: 'Spanish captions',
+        src: '/path/to/spanish-captions.vtt',
+        srclang: 'es',
+      }
+    ]}
+    />
+  )
+  expect(toJson(wrapper, {noKey: true, mode: 'deep'})).toMatchSnapshot();
+});

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders a simple HTML5 Video with Captions 1`] = `
+<video
+  className="react-plyr"
+  poster="/path/to/poster.jpg"
+  src="mymovie.mp4"
+>
+  <track
+    default={true}
+    kind="captions"
+    label="English captions"
+    src="/path/to/english-captions.vtt"
+    srclang="en"
+  />
+  <track
+    kind="captions"
+    label="Spanish captions"
+    src="/path/to/spanish-captions.vtt"
+    srclang="es"
+  />
+</video>
+`;
+
 exports[`renders a simple Vimeo Video 1`] = `
 <div
   className="react-plyr"

--- a/src/defaultProps.js
+++ b/src/defaultProps.js
@@ -208,7 +208,9 @@ const defaultProps = {
   ads: {
     enabled: false,
     publisherId: '',
-  }
+  },
+
+  captions : []
 };
 
 export default defaultProps;

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,18 @@ class Plyr extends Component {
         type: PropTypes.string.isRequired,
         size: PropTypes.string
       })
-    )
+    ),
+
+    captions: PropTypes.arrayOf(
+      PropTypes.shape({
+        kind: PropTypes.string,
+        label: PropTypes.string,
+        src: PropTypes.string.isRequired,
+        srclang: PropTypes.string,
+        default: PropTypes.bool,
+        key: PropTypes.any
+      }),
+    ),
   }
 
   getType = () => this.player && this.player.source && this.player.source.type;
@@ -269,6 +280,7 @@ class Plyr extends Component {
       preload,
       poster,
       className,
+      captions
     } = this.props;
 
     if (sources && Array.isArray(sources) && sources.length) {
@@ -286,6 +298,18 @@ class Plyr extends Component {
               size={source.size && source.size}
             />
           )}
+          {captions.map((source,index)=>{
+            const {key, kind, label, src, srclang, default, ...attributes} = source;
+            return (<track
+              key={key || index}
+              kind={kind}
+              label={label}
+              src={src}
+              srclang={srclang}
+              default={default}
+              {...attributes}
+            />);
+          })}
         </video>
       )
     }

--- a/src/index.js
+++ b/src/index.js
@@ -287,7 +287,7 @@ class Plyr extends Component {
       const {key, kind, label, src, srclang, default: def, ...attributes} = source;
       return (<track
         key={key || index}
-        kind={kind}
+        kind={kind || "captions"}
         label={label}
         src={src}
         srclang={srclang}

--- a/src/index.js
+++ b/src/index.js
@@ -299,14 +299,14 @@ class Plyr extends Component {
             />
           )}
           {captions.map((source,index)=>{
-            const {key, kind, label, src, srclang, default, ...attributes} = source;
+            const {key, kind, label, src, srclang, default: def, ...attributes} = source;
             return (<track
               key={key || index}
               kind={kind}
               label={label}
               src={src}
               srclang={srclang}
-              default={default}
+              default={def}
               {...attributes}
             />);
           })}

--- a/src/index.js
+++ b/src/index.js
@@ -283,6 +283,19 @@ class Plyr extends Component {
       captions
     } = this.props;
 
+    const captionsMap = captions.map((source,index)=>{
+      const {key, kind, label, src, srclang, default: def, ...attributes} = source;
+      return (<track
+        key={key || index}
+        kind={kind}
+        label={label}
+        src={src}
+        srclang={srclang}
+        default={def}
+        {...attributes}
+      />);
+    });
+
     if (sources && Array.isArray(sources) && sources.length) {
       return (
         <video
@@ -298,18 +311,7 @@ class Plyr extends Component {
               size={source.size && source.size}
             />
           )}
-          {captions.map((source,index)=>{
-            const {key, kind, label, src, srclang, default: def, ...attributes} = source;
-            return (<track
-              key={key || index}
-              kind={kind}
-              label={label}
-              src={src}
-              srclang={srclang}
-              default={def}
-              {...attributes}
-            />);
-          })}
+          {captionsMap}
         </video>
       )
     }
@@ -320,7 +322,9 @@ class Plyr extends Component {
         src={url}
         preload={preload}
         poster={poster}
-      />
+      >
+      {captionsMap}
+      </video>
     );
   }
 


### PR DESCRIPTION
Utilize the `track` tag to add captions to HTML5 videos.

- Uses a new prop `captions`
- Added relevant `propTypes`
- Added relevant `defaultProps`
- Added a test case for rendering an HTML5 video with a URL and captions