### PR TITLE
Adding support for more types for controls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,13 @@ class Plyr extends Component {
       enabled: PropTypes.bool,
       key: PropTypes.string
     }),
-    controls: PropTypes.arrayOf(PropTypes.string),
+    controls: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.func,
+      PropTypes.object,
+      PropTypes.bool
+    ]),
     settings: PropTypes.arrayOf(PropTypes.string),
 
     poster: PropTypes.string,


### PR DESCRIPTION
Available types for controls can be more than just an array of strings, it can be an actual markup set. https://github.com/sampotts/plyr/blob/master/controls.md

We can have additional types, please reference this documentation from the original library.