### PR TITLE
update css to fix padding-bottom: 56.25%

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Include the `plyr.css` stylsheet into your `<head>`
 If you want to use our CDN (provided by [Fastly](https://www.fastly.com/)) for the default CSS, you can use the following:
 
 ```html
-<link rel="stylesheet" href="https://cdn.plyr.io/3.5.2/plyr.css">
+<link rel="stylesheet" href="https://cdn.plyr.io/3.5.3/plyr.css">
 ```
 
 ## Usage


### PR DESCRIPTION
There was a serious amount of padding (56.25%) being added to the bottom of the video-wrapper element via inline-styles.  This occurred when using type="video" The version bump from plyr's CSS located on their CDN fixes this UI bug.