### PR TITLE
Change srclang to srcLang in track element.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -355,7 +355,7 @@ class Plyr extends Component {
           kind={kind}
           label={label}
           src={src}
-          srclang={srclang}
+          srcLang={srclang}
           default={def}
           {...attributes}
           ref={this.elementRef}


### PR DESCRIPTION
Only the camel-cased srcLang is a DOM attribute supported by React. Using the lower case will result in the following error: `Invalid DOM property srclang. Did you mean srcLang?`

List of DOM elements supported by React:
https://reactjs.org/docs/dom-elements.html