### PR TITLE
support iOS9

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,8 @@
       "@babel/preset-env",
       {
         "targets": {
-          "esmodules": true
+          "esmodules": true,
+          "safari": "9"
         }
       }
     ]


### PR DESCRIPTION
Now react-plyr would throw errors when used in iOS 9 devices, while plyr itself supports iOS 9. The errors were caused by some JavaScript algorithms like `const` or ` () => {}`.

So just transform them use babel.